### PR TITLE
Use git module instead of symlinks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "simple_extension/pybind11"]
+	path = simple_extension/pybind11
+	url = https://github.com/pybind/pybind11
+	branch = stable

--- a/README.md
+++ b/README.md
@@ -4,22 +4,23 @@ Examples of using pybind11 with Visual Studio 2017 and cmake in a x64 Windows en
 
 # Setup
 
-1. Create symbolic links to pybind11 folder, e.g. on cmd in Admin mode:
+1. Update the sub-module:
 
-    mklink /D D:\pybind11_with_MSVC_2017\simple_extension\pybind11 D:\pybind11
-    
-This needs to be done for each project you like run from this repository.
+    git submodule update --init    
+
+Explanation: Your code "example.cpp" looks for the header files in the pybind11 directory. git submodule command clones the pybind header files from the official repo. 
 
 
 2. Open Visual Studio x64 Native Tools Command Prompt for VS 2017
 
-Build extension
+How to build simple_extension
 
-    cd extension
+    cd simple_extension
     mkdir build
     cd build
     cmake -A x64 ..
     cmake --build . --config Release --target example
+    cd Release
     python
     >>> import example
     >>> example.add(9,7)


### PR DESCRIPTION
Added git submodule to eliminate the use of copy paste. also, python import command didn't work for me from the working directory. so update the readme file too. Thank you very much for putting the example on git 🙇 . 